### PR TITLE
Change the color of the titlebar and borders if their color is set to the accent color and the accent color changes and some other improvements

### DIFF
--- a/examples/wx-example.py
+++ b/examples/wx-example.py
@@ -6,7 +6,7 @@ import wx
 
 app = wx.App()
 
-window = wx.Frame(parent=None, title='hTkT')
+window = wx.Frame(parent=None, title='hPyT')
 
 title_bar.hide(window) 
 # title_bar.unhide(window)

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -1,5 +1,6 @@
 import math
 import threading
+import time
 
 try:
     import ctypes
@@ -68,6 +69,8 @@ class NCCALCSIZE_PARAMS(ctypes.Structure):
 
 rnbtbs = []
 rnbbcs = []
+accent_color_titlebars = []
+accent_color_borders = []
 titles = {}
 
 class title_bar:
@@ -354,6 +357,9 @@ class title_bar_color:
 
         color = convert_color(color)
         hwnd = module_find(window)
+        if hwnd in accent_color_titlebars:
+            accent_color_titlebars.remove(hwnd)
+
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
         set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
@@ -369,13 +375,27 @@ class title_bar_color:
             window (object): The window objec   t to modify (e.g., a Tk instance in Tkinter).
         """
 
+        def set_titlebar_color_accent(hwnd):
+            old_accent = (-1, -1, -1)
+
+            while hwnd in accent_color_titlebars:
+                if not old_accent == get_accent_color():
+                    color = convert_color(get_accent_color())
+                    old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
+                    new_ex_style = old_ex_style | WS_EX_LAYERED
+                    set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
+                    ctypes.windll.dwmapi.DwmSetWindowAttribute(hwnd, 35, ctypes.byref(ctypes.c_int(color)), 4)
+                    set_window_long(hwnd, GWL_EXSTYLE, old_ex_style)  # Reset the window style
+                    
+                    old_accent = get_accent_color()
+
+                time.sleep(1)
+
         hwnd = module_find(window)
-        color = convert_color(get_accent_color())
-        old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
-        new_ex_style = old_ex_style | WS_EX_LAYERED
-        set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
-        ctypes.windll.dwmapi.DwmSetWindowAttribute(hwnd, 35, ctypes.byref(ctypes.c_int(color)), 4)
-        set_window_long(hwnd, GWL_EXSTYLE, old_ex_style)  # Reset the window style
+        accent_color_titlebars.append(hwnd)
+
+        thread = threading.Thread(target = set_titlebar_color_accent, args = (hwnd,), daemon = True)
+        thread.start()
 
     @classmethod
     def reset(cls, window) -> None:
@@ -387,6 +407,9 @@ class title_bar_color:
         """
 
         hwnd = module_find(window)
+        if hwnd in accent_color_titlebars:
+            accent_color_titlebars.remove(hwnd)
+
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
         set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
@@ -538,6 +561,9 @@ class rainbow_title_bar:
                 ctypes.windll.dwmapi.DwmSetWindowAttribute(hwnd, 35, ctypes.byref(ctypes.c_int(-1)), 4)
 
         hwnd = module_find(window)
+        if hwnd in accent_color_titlebars:
+            accent_color_titlebars.remove(hwnd)
+
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
         set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -396,10 +396,13 @@ class title_bar_color:
         hwnd = module_find(window)
         if hwnd in rnbtbs:
             raise RuntimeError('Failed to change the title bar color. Please stop the rainbow titlebar effect using the `stop()` function.')
-        accent_color_titlebars.append(hwnd)
-
-        thread = threading.Thread(target = set_titlebar_color_accent, args = (hwnd,), daemon = True)
-        thread.start()
+        
+        if not hwnd in accent_color_titlebars:
+            accent_color_titlebars.append(hwnd)
+            thread = threading.Thread(target = set_titlebar_color_accent, args = (hwnd,), daemon = True)
+            thread.start()
+        else:
+            raise RuntimeError("The titlebar's color of the specified window is already set to the accent color.")
 
     @classmethod
     def reset(cls, window) -> None:
@@ -519,10 +522,13 @@ class border_color:
         hwnd = module_find(window)
         if hwnd in rnbbcs:
             raise RuntimeError('Failed to change the border color. Please stop the rainbow border effect using the `stop()` function.')
-        accent_color_borders.append(hwnd)
-
-        thread = threading.Thread(target = set_border_color_accent, args = (hwnd,), daemon = True)
-        thread.start()
+        
+        if not hwnd in accent_color_borders:
+            accent_color_borders.append(hwnd)
+            thread = threading.Thread(target = set_border_color_accent, args = (hwnd,), daemon = True)
+            thread.start()
+        else:
+            raise RuntimeError("The border's color of the specified window is already set to the accent color.")
 
     @classmethod
     def reset(cls, window) -> None:

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -359,6 +359,8 @@ class title_bar_color:
         hwnd = module_find(window)
         if hwnd in accent_color_titlebars:
             accent_color_titlebars.remove(hwnd)
+        if hwnd in rnbtbs:
+            raise RuntimeError('Failed to change the title bar color. Please stop the rainbow titlebar effect using the `stop()` function.')
 
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
@@ -392,6 +394,8 @@ class title_bar_color:
                 time.sleep(1)
 
         hwnd = module_find(window)
+        if hwnd in rnbtbs:
+            raise RuntimeError('Failed to change the title bar color. Please stop the rainbow titlebar effect using the `stop()` function.')
         accent_color_titlebars.append(hwnd)
 
         thread = threading.Thread(target = set_titlebar_color_accent, args = (hwnd,), daemon = True)
@@ -409,6 +413,8 @@ class title_bar_color:
         hwnd = module_find(window)
         if hwnd in accent_color_titlebars:
             accent_color_titlebars.remove(hwnd)
+        if hwnd in rnbtbs:
+            raise RuntimeError('Failed to reset the title bar color. Please stop the rainbow titlebar effect using the `stop()` function.')
 
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
@@ -476,6 +482,8 @@ class border_color:
         hwnd = module_find(window)
         if hwnd in accent_color_borders:
             accent_color_borders.remove(hwnd)
+        if hwnd in rnbbcs:
+            raise RuntimeError('Failed to change the border color. Please stop the rainbow border effect using the `stop()` function.')
 
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
@@ -509,6 +517,8 @@ class border_color:
                 time.sleep(1)
 
         hwnd = module_find(window)
+        if hwnd in rnbbcs:
+            raise RuntimeError('Failed to change the border color. Please stop the rainbow border effect using the `stop()` function.')
         accent_color_borders.append(hwnd)
 
         thread = threading.Thread(target = set_border_color_accent, args = (hwnd,), daemon = True)
@@ -526,6 +536,8 @@ class border_color:
         hwnd = module_find(window)
         if hwnd in accent_color_borders:
             accent_color_borders.remove(hwnd)
+        if hwnd in rnbbcs:
+            raise RuntimeError('Failed to reset the border color. Please stop the rainbow border effect using the `stop()` function.')
 
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -474,6 +474,9 @@ class border_color:
 
         color = convert_color(color)
         hwnd = module_find(window)
+        if hwnd in accent_color_borders:
+            accent_color_borders.remove(hwnd)
+
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
         set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
@@ -489,13 +492,27 @@ class border_color:
             window (object): The window object to modify (e.g., a Tk instance in Tkinter).
         """
 
+        def set_border_color_accent(hwnd):
+            old_accent = (-1, -1, -1)
+
+            while hwnd in accent_color_borders:
+                if not old_accent == get_accent_color():
+                    color = convert_color(get_accent_color())
+                    old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
+                    new_ex_style = old_ex_style | WS_EX_LAYERED
+                    set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
+                    ctypes.windll.dwmapi.DwmSetWindowAttribute(hwnd, 34, ctypes.byref(ctypes.c_int(color)), 4)
+                    set_window_long(hwnd, GWL_EXSTYLE, old_ex_style)  # Reset the window style
+
+                    old_accent = get_accent_color()
+
+                time.sleep(1)
+
         hwnd = module_find(window)
-        color = convert_color(get_accent_color())
-        old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
-        new_ex_style = old_ex_style | WS_EX_LAYERED
-        set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
-        ctypes.windll.dwmapi.DwmSetWindowAttribute(hwnd, 34, ctypes.byref(ctypes.c_int(color)), 4)
-        set_window_long(hwnd, GWL_EXSTYLE, old_ex_style)  # Reset the window style
+        accent_color_borders.append(hwnd)
+
+        thread = threading.Thread(target = set_border_color_accent, args = (hwnd,), daemon = True)
+        thread.start()
 
     @classmethod
     def reset(cls, window) -> None:
@@ -507,6 +524,9 @@ class border_color:
         """
 
         hwnd = module_find(window)
+        if hwnd in accent_color_borders:
+            accent_color_borders.remove(hwnd)
+
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
         set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
@@ -657,6 +677,9 @@ class rainbow_border:
                 ctypes.windll.dwmapi.DwmSetWindowAttribute(hwnd, 34, ctypes.byref(ctypes.c_int(-1)), 4)
 
         hwnd = module_find(window)
+        if hwnd in accent_color_borders:
+            accent_color_borders.remove(hwnd)
+
         old_ex_style = get_window_long(hwnd, GWL_EXSTYLE)
         new_ex_style = old_ex_style | WS_EX_LAYERED
         set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -600,10 +600,13 @@ class rainbow_title_bar:
         new_ex_style = old_ex_style | WS_EX_LAYERED
         set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
 
-        rnbtbs.append(hwnd)
-        thread = threading.Thread(target=color_changer, args=(hwnd, interval))
-        thread.daemon = True
-        thread.start()
+        if not hwnd in rnbtbs:
+            rnbtbs.append(hwnd)
+            thread = threading.Thread(target=color_changer, args=(hwnd, interval))
+            thread.daemon = True
+            thread.start()
+        else:
+            raise RuntimeError('The rainbow title bar effect is already applied to this window.')
 
         set_window_long(hwnd, GWL_EXSTYLE, old_ex_style)  # Reset the window style
 
@@ -696,10 +699,13 @@ class rainbow_border:
         new_ex_style = old_ex_style | WS_EX_LAYERED
         set_window_long(hwnd, GWL_EXSTYLE, new_ex_style)
 
-        rnbbcs.append(hwnd)
-        thread = threading.Thread(target=color_changer, args=(hwnd, interval))
-        thread.daemon = True
-        thread.start()
+        if not hwnd in rnbbcs:
+            rnbbcs.append(hwnd)
+            thread = threading.Thread(target=color_changer, args=(hwnd, interval))
+            thread.daemon = True
+            thread.start()
+        else:
+            raise RuntimeError('The rainbow border effect is already applied to this window.')
 
         set_window_long(hwnd, GWL_EXSTYLE, old_ex_style)  # Reset the window style
 


### PR DESCRIPTION
This PR makes the titlebars and window borders that are set to the accent color to change their color if the accent color changes.

https://github.com/user-attachments/assets/7c561175-05bc-4942-9b1d-c7c81ea1e900

If you're wondering why the buttons of the demo program are following the accent color, I use a 3rd party program called [AccentColorizer](https://github.com/krlvm/AccentColorizer) that colorizes window controls with the accent color.

I also made some improvements:
- Raise an exception if someone tries to set the titlebar or border color if the rainbow effect is active in a specific window
- Raise an exception if someone tries to apply the rainbow effect to the titlebar or border if it's already active in a specific window
- Raise an exception if someone tries to set the titlebar or the border color of a specific window to the accent color if it's already set to it

