### PR TITLE
Fixs major bugs while using hPyT with windows 7

### DIFF
--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -2,6 +2,7 @@ import math
 import threading
 import time
 from typing import Any, Tuple, Union, List, Dict
+import platform
 
 try:
     import ctypes
@@ -83,6 +84,7 @@ accent_color_titlebars: List[int] = []
 accent_color_borders: List[int] = []
 titles: dict = {}
 
+WINDOWS_VERSION = float(platform.version().split('.')[0])
 
 class title_bar:
     """Hide or unhide the title bar of a window."""
@@ -104,9 +106,11 @@ class title_bar:
         def handle(hwnd: int, msg: int, wp: int, lp: int) -> int:
             if msg == WM_NCCALCSIZE and wp:
                 # Adjust the non-client area (title bar) size
-                # Here we are basically removing the top border (because the title bar in windows is made of 2 components: the actual titlebar and the border, both having same color)
-                lpncsp = NCCALCSIZE_PARAMS.from_address(lp)
-                lpncsp.rgrc[0].top -= border_width  # Reduce the height of the title bar
+                # Only apply the changes on windows 8 and above
+                if WINDOWS_VERSION >= 6.2: # Windows 8 is version 6.2, Windows 10 is version 10.0
+                    # Here we are basically removing the top border (because the title bar in windows is made of 2 components: the actual titlebar and the border, both having same color)
+                    lpncsp = NCCALCSIZE_PARAMS.from_address(lp)
+                    lpncsp.rgrc[0].top -= border_width  # Reduce the height of the title bar
 
             elif msg in [WM_NCACTIVATE, WM_NCPAINT]:
                 # Prevent Windows from drawing the title bar when the window is activated or painted

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -12,8 +12,16 @@ except ImportError:
     raise ImportError("hPyT import Error : No Windows Enviorment Found")
 
 set_window_pos = ctypes.windll.user32.SetWindowPos
-set_window_long = ctypes.windll.user32.SetWindowLongPtrW
-get_window_long = ctypes.windll.user32.GetWindowLongPtrA
+
+# Check if the system is 32-bit or 64-bit
+# GetWindowLongPtrA and SetWindowLongPtrA are not supported in 32-bit systems
+if platform.architecture()[0] == '64bit':
+    set_window_long = ctypes.windll.user32.SetWindowLongPtrW
+    get_window_long = ctypes.windll.user32.GetWindowLongPtrA
+else:
+    set_window_long = ctypes.windll.user32.SetWindowLongW
+    get_window_long = ctypes.windll.user32.GetWindowLongA
+
 def_window_proc = ctypes.windll.user32.DefWindowProcW
 call_window_proc = ctypes.windll.user32.CallWindowProcW
 flash_window_ex = ctypes.windll.user32.FlashWindowEx

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -1256,7 +1256,10 @@ class title_text:
             title = ctypes.create_unicode_buffer(1024)
             ctypes.windll.user32.GetWindowTextW(hwnd, title, 1024)
             titles[hwnd] = title.value
-        title = ctypes.create_unicode_buffer(stylize_text(titles[hwnd], style))
+        stylized_title = stylize_text(titles[hwnd], style)
+        title = ctypes.create_unicode_buffer(
+            stylized_title, size=len(stylized_title.encode("unicode_escape"))
+        )
         ctypes.windll.user32.SetWindowTextW(hwnd, title)
 
     @classmethod
@@ -1309,7 +1312,7 @@ def stylize_text(text: str, style: int) -> str:
     if style < 1 or style > len(styles):
         raise ValueError("Invalid style number")
 
-    translation_table: dict[int, int] = str.maketrans(normal, styles[style - 1])
+    translation_table: Dict[int, int] = str.maketrans(normal, styles[style - 1])
     return text.translate(translation_table)
 
 


### PR DESCRIPTION
**Bug Fixes**:

- Add a check to prevent removal of top border in `title_bar.hide` function on windows version 7 and lower.
- Implement architecture-based window function selection for 32-bit and 64-bit systems
- Update the Unicode buffer size calculation for stylized titles.

This issue address Issue #50 