### PR TITLE
Add synchronized rainbow effects for title bar and border

### DIFF
--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -192,7 +192,7 @@ class synchronized_rainbow:
         if sync_is_running:
             sync_is_running = False
             # Wait for the thread to finish cleanly
-            if threading.current_thread() is not sync_color_thread:
+            if sync_color_thread is not None and threading.current_thread() is not sync_color_thread:
                 sync_color_thread.join(timeout=0.1)
             sync_color_thread = None
 

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -192,7 +192,10 @@ class synchronized_rainbow:
         if sync_is_running:
             sync_is_running = False
             # Wait for the thread to finish cleanly
-            if sync_color_thread is not None and threading.current_thread() is not sync_color_thread:
+            if (
+                sync_color_thread is not None
+                and threading.current_thread() is not sync_color_thread
+            ):
                 sync_color_thread.join(timeout=0.1)
             sync_color_thread = None
 


### PR DESCRIPTION
Introduce a new 'synchronized_rainbow' class to manage a single, module-level color cycle thread.

This allows the 'rainbow_title_bar' and 'rainbow_border' effects to run in a synchronized mode (using `start_sync()`), ensuring all rainbow elements change color at the exact same time.

The original single-element rainbow effects remain unchanged for backward compatibility.

https://github.com/user-attachments/assets/a1e3a856-7e15-40c5-933b-7e5ed2c04588

## Summary by Sourcery

Add a module-level synchronization mechanism that drives a single rainbow color cycle thread and extend the title bar and border effects to run in lockstep using this shared manager.

New Features:
- Implement synchronized_rainbow class to coordinate a single color-cycling thread with start, stop, and get_current_color methods
- Add start_sync and stop_sync methods to rainbow_title_bar for synchronized color updates using the shared thread
- Add start_sync and stop_sync methods to rainbow_border for synchronized color updates using the shared thread

Enhancements:
- Retain existing rainbow_title_bar.start/stop and rainbow_border.start/stop behavior for backward compatibility
- Introduce stop_sync_if_last helper to automatically shut down the master thread when no synchronized effects remain