### PR TITLE
Fix Python crash when hiding the title bar of more windows

### DIFF
--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -95,6 +95,8 @@ rnbtbs: List[int] = []
 rnbbcs: List[int] = []
 accent_color_titlebars: List[int] = []
 accent_color_borders: List[int] = []
+old_wndprocs: Dict[int, ctypes.c_uint64] = {}
+new_wndprocs: Dict[int, ctypes.c_uint64] = {}
 
 WINDOWS_VERSION = float(platform.version().split(".")[0])
 
@@ -130,10 +132,11 @@ class title_bar:
 
             # Default processing for other messages
             return call_window_proc(
-                *map(ctypes.c_uint64, (globals()[old], hwnd, msg, wp, lp))
+                *map(ctypes.c_uint64, (old_wndprocs[hwnd], hwnd, msg, wp, lp))
             )
 
-        old, new = "old_wndproc", "new_wndproc"
+        hwnd: int = module_find(window)
+
         prototype = ctypes.WINFUNCTYPE(
             ctypes.c_uint64,
             ctypes.c_uint64,
@@ -141,8 +144,6 @@ class title_bar:
             ctypes.c_uint64,
             ctypes.c_uint64,
         )
-
-        hwnd: int = module_find(window)
 
         # Get the window and client dimensions
         rect = RECT()
@@ -160,13 +161,13 @@ class title_bar:
         title_bar_height: int = full_height - client_height - border_width
 
         # Override the window procedure if not already done
-        if globals().get(old) is None:
-            globals()[old] = get_window_long(hwnd, GWL_WNDPROC)
+        if old_wndprocs.get(hwnd, 0) == 0:
+            old_wndprocs[hwnd] = get_window_long(hwnd, GWL_WNDPROC)
 
         # Do not remove the top border when on windows 7 or lower
         if WINDOWS_VERSION >= 10.0:  # Windows 10 is version 10.0
-            globals()[new] = prototype(handle)
-            set_window_long(hwnd, GWL_WNDPROC, globals()[new])
+            new_wndprocs[hwnd] = prototype(handle)
+            set_window_long(hwnd, GWL_WNDPROC, new_wndprocs[hwnd])
 
         old_style = get_window_long(hwnd, GWL_STYLE)
         new_style = (old_style & ~WS_CAPTION) | WS_BORDER
@@ -206,9 +207,10 @@ class title_bar:
 
         hwnd: int = module_find(window)
 
-        if globals().get("old_wndproc") is not None:
-            set_window_long(hwnd, GWL_WNDPROC, globals()["old_wndproc"])
-            globals()["old_wndproc"] = None
+        if old_wndprocs.get(hwnd, 0) != 0:
+            set_window_long(hwnd, GWL_WNDPROC, old_wndprocs[hwnd])
+            old_wndprocs.pop(hwnd)
+            new_wndprocs.pop(hwnd)
 
         # Restore the original height if no_span was used
         height_reduction: int = cls._height_reduction.pop(hwnd, 0)

--- a/hPyT/hPyT.py
+++ b/hPyT/hPyT.py
@@ -95,8 +95,8 @@ rnbtbs: List[int] = []
 rnbbcs: List[int] = []
 accent_color_titlebars: List[int] = []
 accent_color_borders: List[int] = []
-old_wndprocs: Dict[int, ctypes.c_uint64] = {}
-new_wndprocs: Dict[int, ctypes.c_uint64] = {}
+old_wndprocs: Dict[int, Any] = {}
+new_wndprocs: Dict[int, Any] = {}
 
 WINDOWS_VERSION = float(platform.version().split(".")[0])
 


### PR DESCRIPTION
I found out why the crash in #59 was happening while experimenting with window procedures in a project of mine: it is because the code stores the window procedures (the old and the new ones) in the same variables, regardless of the window. When storing the second window's procedures, the procedures of the first one are lost and that's why the crash is happening. This PR addresses this issue by storing the window procedures ~~in unique variables for every window~~ in 2 different dictionaries: one for the old ones and another one for the new ones. Fixes #59.

## Summary by Sourcery

Ensure window procedure hooks are stored and restored per-window to prevent crashes when manipulating multiple windows.

Bug Fixes:
- Store old and new window procedures under hwnd-specific identifiers so each window maintains its own procedures.
- Restore the original window procedure using the hwnd-specific stored value when unhiding a window.